### PR TITLE
Print log for instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ new Dummy().hello("Foo");
 // [Dummy#hello] Return: Hi Foo
 ```
 
+### PrintLogProxy
+
+PrintLog for any instance.
+
+```javascript
+import * as fs from "fs";
+PrintLogProxy(fs, "existsSync", { className: "Fs" });
+fs.existsSync(`./package.json`);
+// [Fs#existsSync] Call with args: ["./package.json"]
+// [Fs#existsSync] Return: true
+```
+
 ## Request context
 
 Help to trace called methods in the same request.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Use decorators for trace your class methods
 ### PrintLog
 
 ```javascript
+import { PrintLog } from "nestjs-tracer";
+
 class Dummy {
   @PrintLog
   hello(name) {
@@ -19,6 +21,8 @@ new Dummy().hello("Foo");
 ### PrintLogAsync
 
 ```javascript
+import { PrintLogAsync } from "nestjs-tracer";
+
 class Dummy {
   @PrintLogAsync
   async hello(name) {
@@ -35,6 +39,8 @@ new Dummy().hello("Foo");
 PrintLog for any instance.
 
 ```javascript
+import { PrintLogProxy } from "nestjs-tracer";
+
 import * as fs from "fs";
 PrintLogProxy(fs, "existsSync", { className: "Fs" });
 fs.existsSync(`./package.json`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-tracer",
-  "version": "0.2.6",
+  "version": "0.3.6",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/PrintLogger.ts
+++ b/src/PrintLogger.ts
@@ -21,27 +21,27 @@ export const PrintLogProxyAsync = Logger => (
   const original = instance[methodName];
   const proxy = new Proxy(
     original,
-    proxyHandlerAsync({ Logger, className, methodName: name })
+    proxyHandlerAsync({ Logger, className, methodName })
   );
   instance[methodName] = proxy;
 };
 
-export const PrintLog = Logger => (target, name, descriptor) => {
+export const PrintLog = Logger => (target, methodName, descriptor) => {
   const className = target.constructor.name;
   const original = descriptor.value;
   const proxy = new Proxy(
     original,
-    proxyHandler({ Logger, className, methodName: name })
+    proxyHandler({ Logger, className, methodName })
   );
   descriptor.value = proxy;
 };
 
-export const PrintLogAsync = Logger => (target, name, descriptor) => {
+export const PrintLogAsync = Logger => (target, methodName, descriptor) => {
   const className = target.constructor.name;
   const original = descriptor.value;
   const proxy = new Proxy(
     original,
-    proxyHandlerAsync({ Logger, className, methodName: name })
+    proxyHandlerAsync({ Logger, className, methodName })
   );
   descriptor.value = proxy;
 };
@@ -65,7 +65,7 @@ const proxyHandlerAsync = ({ Logger, className, methodName }) => ({
   apply: function(target, thisArg, args) {
     Logger.log(
       `Call with args: ${JSON.stringify(args)}`,
-      `${className}#${name}`
+      `${className}#${methodName}`
     );
     const result = target.apply(thisArg, args);
     result

--- a/src/PrintLogger.ts
+++ b/src/PrintLogger.ts
@@ -1,12 +1,24 @@
-// interface ITarget {
-//   constructor: {
-//     name: string;
-//   };
-// }
+export const PrintLogProxy = Logger => (instance, methodName) => {
+  const className = typeof instance;
+  const original = instance[methodName];
+  const handler = {
+    apply: function(target, thisArg, args) {
+      Logger.log(
+        `Call with args: ${JSON.stringify(args)}`,
+        `${className}#${methodName}`
+      );
+      const result = target.apply(thisArg, args);
+      Logger.log(
+        `Return: ${JSON.stringify(result)}`,
+        `${className}#${methodName}`
+      );
+      return result;
+    }
+  };
+  const proxy = new Proxy(original, handler);
+  instance[methodName] = proxy;
+};
 
-// interface IDescriptor {
-//   value: any;
-// }
 export const PrintLog = Logger => (target, name, descriptor) => {
   const className = target.constructor.name;
   const original = descriptor.value;

--- a/src/PrintLogger.ts
+++ b/src/PrintLogger.ts
@@ -3,7 +3,7 @@ export const PrintLogProxy = Logger => (
   methodName,
   options: { className?: string } = {}
 ) => {
-  const className = options.className || typeof instance;
+  const className = options.className || instance.constructor.name;
   const original = instance[methodName];
   const handler = {
     apply: function(target, thisArg, args) {

--- a/src/PrintLogger.ts
+++ b/src/PrintLogger.ts
@@ -23,6 +23,28 @@ export const PrintLogProxy = Logger => (
   instance[methodName] = proxy;
 };
 
+export const PrintLogProxyAsync = Logger => (
+  instance,
+  methodName,
+  options: { className?: string } = {}
+) => {
+  const className = options.className || instance.constructor.name;
+  const original = instance[methodName];
+  const handler = {
+    apply: function(target, thisArg, args) {
+      Logger.log(
+        `Call with args: ${JSON.stringify(args)}`,
+        `${className}#${name}`
+      );
+      const result = target.apply(thisArg, args);
+      Logger.log(`Return: ${JSON.stringify(result)}`, `${className}#${name}`);
+      return result;
+    }
+  };
+  const proxy = new Proxy(original, handler);
+  instance[methodName] = proxy;
+};
+
 export const PrintLog = Logger => (target, name, descriptor) => {
   const className = target.constructor.name;
   const original = descriptor.value;

--- a/src/PrintLogger.ts
+++ b/src/PrintLogger.ts
@@ -1,3 +1,12 @@
+// interface ITarget {
+//   constructor: {
+//     name: string;
+//   };
+// }
+
+// interface IDescriptor {
+//   value: any;
+// }
 export const PrintLog = Logger => (target, name, descriptor) => {
   const className = target.constructor.name;
   const original = descriptor.value;

--- a/src/PrintLogger.ts
+++ b/src/PrintLogger.ts
@@ -5,21 +5,10 @@ export const PrintLogProxy = Logger => (
 ) => {
   const className = options.className || instance.constructor.name;
   const original = instance[methodName];
-  const handler = {
-    apply: function(target, thisArg, args) {
-      Logger.log(
-        `Call with args: ${JSON.stringify(args)}`,
-        `${className}#${methodName}`
-      );
-      const result = target.apply(thisArg, args);
-      Logger.log(
-        `Return: ${JSON.stringify(result)}`,
-        `${className}#${methodName}`
-      );
-      return result;
-    }
-  };
-  const proxy = new Proxy(original, handler);
+  const proxy = new Proxy(
+    original,
+    proxyHandler({ Logger, className, methodName })
+  );
   instance[methodName] = proxy;
 };
 
@@ -30,62 +19,63 @@ export const PrintLogProxyAsync = Logger => (
 ) => {
   const className = options.className || instance.constructor.name;
   const original = instance[methodName];
-  const handler = {
-    apply: function(target, thisArg, args) {
-      Logger.log(
-        `Call with args: ${JSON.stringify(args)}`,
-        `${className}#${name}`
-      );
-      const result = target.apply(thisArg, args);
-      Logger.log(`Return: ${JSON.stringify(result)}`, `${className}#${name}`);
-      return result;
-    }
-  };
-  const proxy = new Proxy(original, handler);
+  const proxy = new Proxy(
+    original,
+    proxyHandlerAsync({ Logger, className, methodName: name })
+  );
   instance[methodName] = proxy;
 };
 
 export const PrintLog = Logger => (target, name, descriptor) => {
   const className = target.constructor.name;
   const original = descriptor.value;
-
-  const handler = {
-    apply: function(target, thisArg, args) {
-      Logger.log(
-        `Call with args: ${JSON.stringify(args)}`,
-        `${className}#${name}`
-      );
-      const result = target.apply(thisArg, args);
-      Logger.log(`Return: ${JSON.stringify(result)}`, `${className}#${name}`);
-      return result;
-    }
-  };
-  const proxy = new Proxy(original, handler);
+  const proxy = new Proxy(
+    original,
+    proxyHandler({ Logger, className, methodName: name })
+  );
   descriptor.value = proxy;
 };
 
 export const PrintLogAsync = Logger => (target, name, descriptor) => {
   const className = target.constructor.name;
   const original = descriptor.value;
-
-  const handler = {
-    apply: function(target, thisArg, args) {
-      Logger.log(
-        `Call with args: ${JSON.stringify(args)}`,
-        `${className}#${name}`
-      );
-      const result = original.apply(thisArg, args);
-      result
-        .then(result => {
-          Logger.log(
-            `Return: ${JSON.stringify(result)}`,
-            `${className}#${name}`
-          );
-        })
-        .catch(error => {});
-      return result;
-    }
-  };
-  const proxy = new Proxy(original, handler);
+  const proxy = new Proxy(
+    original,
+    proxyHandlerAsync({ Logger, className, methodName: name })
+  );
   descriptor.value = proxy;
 };
+
+const proxyHandler = ({ Logger, className, methodName }) => ({
+  apply: function(target, thisArg, args) {
+    Logger.log(
+      `Call with args: ${JSON.stringify(args)}`,
+      `${className}#${methodName}`
+    );
+    const result = target.apply(thisArg, args);
+    Logger.log(
+      `Return: ${JSON.stringify(result)}`,
+      `${className}#${methodName}`
+    );
+    return result;
+  }
+});
+
+const proxyHandlerAsync = ({ Logger, className, methodName }) => ({
+  apply: function(target, thisArg, args) {
+    Logger.log(
+      `Call with args: ${JSON.stringify(args)}`,
+      `${className}#${name}`
+    );
+    const result = target.apply(thisArg, args);
+    result
+      .then(result => {
+        Logger.log(
+          `Return: ${JSON.stringify(result)}`,
+          `${className}#${methodName}`
+        );
+      })
+      .catch(error => {});
+    return result;
+  }
+});

--- a/src/PrintLogger.ts
+++ b/src/PrintLogger.ts
@@ -1,5 +1,9 @@
-export const PrintLogProxy = Logger => (instance, methodName) => {
-  const className = typeof instance;
+export const PrintLogProxy = Logger => (
+  instance,
+  methodName,
+  options: { className?: string } = {}
+) => {
+  const className = options.className || typeof instance;
   const original = instance[methodName];
   const handler = {
     apply: function(target, thisArg, args) {

--- a/src/__tests__/PrintLogger.spec.ts
+++ b/src/__tests__/PrintLogger.spec.ts
@@ -1,5 +1,5 @@
+import * as fs from "fs";
 import { PrintLog, PrintLogAsync, PrintLogProxy } from "..";
-
 import { Logger } from "@nestjs/common";
 
 class Dummy {
@@ -61,6 +61,18 @@ describe("PrintLog", () => {
       PrintLogProxy(instance, "hello");
       instance.hello("Foo");
       expect(spy).nthCalledWith(1, 'Call with args: ["Foo"]', "Dummy#hello");
+    });
+
+    it("example for fs object", () => {
+      const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
+      PrintLogProxy(fs, "existsSync", { className: "Fs" });
+      fs.existsSync(`./package.json`);
+      expect(spy).nthCalledWith(
+        1,
+        'Call with args: ["./package.json"]',
+        "Fs#existsSync"
+      );
+      expect(spy).nthCalledWith(2, "Return: true", "Fs#existsSync");
     });
   });
 

--- a/src/__tests__/PrintLogger.spec.ts
+++ b/src/__tests__/PrintLogger.spec.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import { PrintLog, PrintLogAsync, PrintLogProxy } from "..";
+import { PrintLog, PrintLogAsync, PrintLogProxy, PrintLogProxyAsync } from "..";
 import { Logger } from "@nestjs/common";
 
 class Dummy {
@@ -29,6 +29,14 @@ class Dummy {
 describe("PrintLog", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it("#PrintLogProxyAsync", async () => {
+    const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
+    const instance = { hello: async name => `Hi ${name}` };
+    PrintLogProxyAsync(instance, "hello");
+    await instance.hello("Foo");
+    expect(spy).toBeCalled();
   });
 
   describe("#PrintLogProxy", () => {

--- a/src/__tests__/PrintLogger.spec.ts
+++ b/src/__tests__/PrintLogger.spec.ts
@@ -36,7 +36,8 @@ describe("PrintLog", () => {
     const instance = { hello: async name => `Hi ${name}` };
     PrintLogProxyAsync(instance, "hello");
     await instance.hello("Foo");
-    expect(spy).toBeCalled();
+    expect(spy).nthCalledWith(1, 'Call with args: ["Foo"]', "Object#hello");
+    expect(spy).nthCalledWith(2, 'Return: "Hi Foo"', "Object#hello");
   });
 
   describe("#PrintLogProxy", () => {

--- a/src/__tests__/PrintLogger.spec.ts
+++ b/src/__tests__/PrintLogger.spec.ts
@@ -31,16 +31,24 @@ describe("PrintLog", () => {
     jest.clearAllMocks();
   });
 
-  it("#PrintLogProxy", () => {
-    const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
-    const instance = {
-      hi: name => `Hi ${name}`
-    };
-    PrintLogProxy(instance, "hi");
-    expect(instance.hi("Foo")).toEqual(`Hi Foo`);
-    expect(spy).toBeCalled();
-    expect(spy).nthCalledWith(1, 'Call with args: ["Foo"]', "object#hi");
-    expect(spy).nthCalledWith(2, 'Return: "Hi Foo"', "object#hi");
+  describe("#PrintLogProxy", () => {
+    it("call", () => {
+      const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
+      const instance = { hi: name => `Hi ${name}` };
+      PrintLogProxy(instance, "hi");
+      expect(instance.hi("Foo")).toEqual(`Hi Foo`);
+      expect(spy).toBeCalled();
+      expect(spy).nthCalledWith(1, 'Call with args: ["Foo"]', "object#hi");
+      expect(spy).nthCalledWith(2, 'Return: "Hi Foo"', "object#hi");
+    });
+
+    it("change className", () => {
+      const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
+      const instance = { hi: name => `Hi ${name}` };
+      PrintLogProxy(instance, "hi", { className: "Dummy" });
+      instance.hi("Foo");
+      expect(spy).nthCalledWith(1, 'Call with args: ["Foo"]', "Dummy#hi");
+    });
   });
 
   it("#PrintLog", () => {

--- a/src/__tests__/PrintLogger.spec.ts
+++ b/src/__tests__/PrintLogger.spec.ts
@@ -1,5 +1,4 @@
-import { PrintLog, PrintLogAsync } from "..";
-import { PrintLog as PrintLogger } from "../PrintLogger";
+import { PrintLog, PrintLogAsync, PrintLogProxy } from "..";
 
 import { Logger } from "@nestjs/common";
 
@@ -32,14 +31,16 @@ describe("PrintLog", () => {
     jest.clearAllMocks();
   });
 
-  it("#PrintLogger", () => {
+  it("#PrintLogProxy", () => {
     const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
     const instance = {
-      value: name => `Hi ${name}`
+      hi: name => `Hi ${name}`
     };
-    PrintLogger(Logger)({ constructor: { name: "Object" } }, name, instance);
-    expect(instance.value("Foo")).toEqual(`Hi Foo`);
+    PrintLogProxy(instance, "hi");
+    expect(instance.hi("Foo")).toEqual(`Hi Foo`);
     expect(spy).toBeCalled();
+    expect(spy).nthCalledWith(1, 'Call with args: ["Foo"]', "object#hi");
+    expect(spy).nthCalledWith(2, 'Return: "Hi Foo"', "object#hi");
   });
 
   it("#PrintLog", () => {

--- a/src/__tests__/PrintLogger.spec.ts
+++ b/src/__tests__/PrintLogger.spec.ts
@@ -1,4 +1,6 @@
 import { PrintLog, PrintLogAsync } from "..";
+import { PrintLog as PrintLogger } from "../PrintLogger";
+
 import { Logger } from "@nestjs/common";
 
 class Dummy {
@@ -26,22 +28,33 @@ class Dummy {
 }
 
 describe("PrintLog", () => {
-  it("#PrintLog", () => {
+  beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it("#PrintLogger", () => {
+    const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
+    const instance = {
+      value: name => `Hi ${name}`
+    };
+    PrintLogger(Logger)({ constructor: { name: "Object" } }, name, instance);
+    expect(instance.value("Foo")).toEqual(`Hi Foo`);
+    expect(spy).toBeCalled();
+  });
+
+  it("#PrintLog", () => {
     const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
     expect(new Dummy().hello("Foo")).toEqual(`Hi Foo`);
     expect(spy).toBeCalled();
   });
 
   it("#PrintLogAsync", async () => {
-    jest.clearAllMocks();
     const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
     expect(await new Dummy().helloAsync("Bazz")).toEqual(`Hi Bazz`);
     expect(spy).toBeCalled();
   });
 
   it("#PrintLogAsync handler promise rejects catch", async () => {
-    jest.clearAllMocks();
     const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
     try {
       await new Dummy().helloAsyncErrorPromise("Bazz");

--- a/src/__tests__/PrintLogger.spec.ts
+++ b/src/__tests__/PrintLogger.spec.ts
@@ -34,20 +34,33 @@ describe("PrintLog", () => {
   describe("#PrintLogProxy", () => {
     it("call", () => {
       const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
-      const instance = { hi: name => `Hi ${name}` };
-      PrintLogProxy(instance, "hi");
-      expect(instance.hi("Foo")).toEqual(`Hi Foo`);
+      const instance = { hello: name => `Hi ${name}` };
+      PrintLogProxy(instance, "hello");
+      expect(instance.hello("Foo")).toEqual(`Hi Foo`);
       expect(spy).toBeCalled();
-      expect(spy).nthCalledWith(1, 'Call with args: ["Foo"]', "object#hi");
-      expect(spy).nthCalledWith(2, 'Return: "Hi Foo"', "object#hi");
+      expect(spy).nthCalledWith(1, 'Call with args: ["Foo"]', "Object#hello");
+      expect(spy).nthCalledWith(2, 'Return: "Hi Foo"', "Object#hello");
     });
 
     it("change className", () => {
       const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
-      const instance = { hi: name => `Hi ${name}` };
-      PrintLogProxy(instance, "hi", { className: "Dummy" });
-      instance.hi("Foo");
-      expect(spy).nthCalledWith(1, 'Call with args: ["Foo"]', "Dummy#hi");
+      const instance = { hello: name => `Hi ${name}` };
+      PrintLogProxy(instance, "hello", { className: "Dummy" });
+      instance.hello("Foo");
+      expect(spy).nthCalledWith(1, 'Call with args: ["Foo"]', "Dummy#hello");
+    });
+
+    it("with custom class", () => {
+      const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
+      class Dummy {
+        hello(name) {
+          `Hi ${name}`;
+        }
+      }
+      const instance = new Dummy();
+      PrintLogProxy(instance, "hello");
+      instance.hello("Foo");
+      expect(spy).nthCalledWith(1, 'Call with args: ["Foo"]', "Dummy#hello");
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,10 @@ import { Logger } from "@nestjs/common";
 
 import {
   PrintLog as PrintLogCore,
-  PrintLogAsync as PrintLogCoreAsync
+  PrintLogAsync as PrintLogCoreAsync,
+  PrintLogProxy as PrintLogProxyCore
 } from "./PrintLogger";
 
 export const PrintLog = PrintLogCore(Logger);
 export const PrintLogAsync = PrintLogCoreAsync(Logger);
+export const PrintLogProxy = PrintLogProxyCore(Logger);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,11 @@ import { Logger } from "@nestjs/common";
 import {
   PrintLog as PrintLogCore,
   PrintLogAsync as PrintLogCoreAsync,
-  PrintLogProxy as PrintLogProxyCore
+  PrintLogProxy as PrintLogProxyCore,
+  PrintLogProxyAsync as PrintLogProxyCoreAsync
 } from "./PrintLogger";
 
 export const PrintLog = PrintLogCore(Logger);
 export const PrintLogAsync = PrintLogCoreAsync(Logger);
 export const PrintLogProxy = PrintLogProxyCore(Logger);
+export const PrintLogProxyAsync = PrintLogProxyCoreAsync(Logger);

--- a/src/request-context/index.ts
+++ b/src/request-context/index.ts
@@ -3,9 +3,11 @@ export { ContextService } from "./ContextService";
 
 import {
   PrintLog as PrintLogCore,
-  PrintLogAsync as PrintLogCoreAsync
+  PrintLogAsync as PrintLogCoreAsync,
+  PrintLogProxy as PrintLogProxyCore
 } from "../PrintLogger";
 
 export const PrintLog = PrintLogCore(RequestLogger);
 export const PrintLogAsync = PrintLogCoreAsync(RequestLogger);
+export const PrintLogProxy = PrintLogProxyCore(RequestLogger);
 export { RequestLogger };

--- a/src/request-context/index.ts
+++ b/src/request-context/index.ts
@@ -4,10 +4,12 @@ export { ContextService } from "./ContextService";
 import {
   PrintLog as PrintLogCore,
   PrintLogAsync as PrintLogCoreAsync,
-  PrintLogProxy as PrintLogProxyCore
+  PrintLogProxy as PrintLogProxyCore,
+  PrintLogProxyAsync as PrintLogProxyCoreAsync
 } from "../PrintLogger";
 
 export const PrintLog = PrintLogCore(RequestLogger);
 export const PrintLogAsync = PrintLogCoreAsync(RequestLogger);
 export const PrintLogProxy = PrintLogProxyCore(RequestLogger);
+export const PrintLogProxyAsync = PrintLogProxyCoreAsync(RequestLogger);
 export { RequestLogger };


### PR DESCRIPTION
Some instances we can't use decorators, PrintLogProxy help to trace instance methods.

Example:
Trace Fs#existsSync method.

```typescript
import { PrintLogProxy } from "nestjs-tracer";
import * as fs from "fs";

PrintLogProxy(fs, "existsSync", { className: "Fs" });
```
