### PR TITLE
Fix/circular object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -772,6 +772,11 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
     },
+    "circular-json": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz",
+      "integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ=="
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
+    "circular-json": "^0.5.9",
     "uuid": "^3.3.2"
   }
 }

--- a/src/PrintLogger.ts
+++ b/src/PrintLogger.ts
@@ -37,6 +37,16 @@ export const PrintLog = ({ Logger }: PrintLogOptions) => (
   descriptor.value = proxy;
 };
 
+export const printMessage = (
+  Logger: Logger,
+  value: any,
+  contextTag: string,
+  type: "before" | "after"
+) => {
+  const message = type === "after" ? "Return:" : "Call with args:";
+  Logger.log(`${message} ${CircularJSON.stringify(value)}`, contextTag);
+};
+
 export const handlerBeforeCall = ({
   Logger,
   className,
@@ -48,10 +58,7 @@ export const handlerBeforeCall = ({
   methodName: string;
   args: any;
 }) => {
-  Logger.log(
-    `Call with args: ${CircularJSON.stringify(args)}`,
-    `${className}#${methodName}`
-  );
+  printMessage(Logger, args, `${className}#${methodName}`, "before");
 };
 
 export const handlerAfterCall = ({
@@ -65,10 +72,7 @@ export const handlerAfterCall = ({
   methodName: string;
   result: any;
 }) => {
-  Logger.log(
-    `Return: ${CircularJSON.stringify(result)}`,
-    `${className}#${methodName}`
-  );
+  printMessage(Logger, result, `${className}#${methodName}`, "after");
 };
 
 const proxyHandler = ({

--- a/src/PrintLogger.ts
+++ b/src/PrintLogger.ts
@@ -35,7 +35,7 @@ export const PrintLog = ({ Logger }: PrintLogOptions) => (
   descriptor.value = proxy;
 };
 
-const handlerBeforCall = ({
+export const handlerBeforeCall = ({
   Logger,
   className,
   methodName,
@@ -70,7 +70,7 @@ const proxyHandler = ({
   Logger,
   className,
   methodName,
-  onBeforeCall = handlerBeforCall,
+  onBeforeCall = handlerBeforeCall,
   onAfterCall = handlerAfterCall
 }) => ({
   apply: function(target, thisArg, args) {

--- a/src/PrintLogger.ts
+++ b/src/PrintLogger.ts
@@ -1,3 +1,5 @@
+import * as CircularJSON from "circular-json";
+
 interface Logger {
   log(message: any, context?: string): void;
   error(message: any, trace?: string, context?: string): void;
@@ -47,12 +49,12 @@ export const handlerBeforeCall = ({
   args: any;
 }) => {
   Logger.log(
-    `Call with args: ${JSON.stringify(args)}`,
+    `Call with args: ${CircularJSON.stringify(args)}`,
     `${className}#${methodName}`
   );
 };
 
-const handlerAfterCall = ({
+export const handlerAfterCall = ({
   Logger,
   className,
   methodName,
@@ -63,7 +65,10 @@ const handlerAfterCall = ({
   methodName: string;
   result: any;
 }) => {
-  Logger.log(`Return: ${JSON.stringify(result)}`, `${className}#${methodName}`);
+  Logger.log(
+    `Return: ${CircularJSON.stringify(result)}`,
+    `${className}#${methodName}`
+  );
 };
 
 const proxyHandler = ({

--- a/src/PrintLogger.ts
+++ b/src/PrintLogger.ts
@@ -47,7 +47,7 @@ export const printMessage = (
   Logger.log(`${message} ${CircularJSON.stringify(value)}`, contextTag);
 };
 
-export const handlerBeforeCall = ({
+const handlerBeforeCall = ({
   Logger,
   className,
   methodName,
@@ -61,7 +61,7 @@ export const handlerBeforeCall = ({
   printMessage(Logger, args, `${className}#${methodName}`, "before");
 };
 
-export const handlerAfterCall = ({
+const handlerAfterCall = ({
   Logger,
   className,
   methodName,

--- a/src/__tests__/PrintLogger.spec.ts
+++ b/src/__tests__/PrintLogger.spec.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import { PrintLog, PrintLogProxy } from "..";
 import { Logger } from "@nestjs/common";
+import { handlerBeforeCall } from "../PrintLogger";
 
 class Dummy {
   @PrintLog()
@@ -116,5 +117,37 @@ describe("PrintLog", () => {
       expect(error).toMatchInlineSnapshot(`[Error: Error Bazz]`);
       expect(spy).toBeCalled();
     }
+  });
+
+  describe("#handlerBeforeCall", () => {
+    it("call", () => {
+      const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
+      handlerBeforeCall({
+        Logger,
+        className: "Example",
+        methodName: "example",
+        args: [1, 2]
+      });
+
+      expect(spy).toBeCalledWith("Call with args: [1,2]", "Example#example");
+    });
+
+    it("circular Object", () => {
+      const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
+
+      const object = { arr: undefined, obj: undefined };
+      object.arr = [object, object];
+      object.arr.push(object.arr);
+      object.obj = object;
+
+      handlerBeforeCall({
+        Logger,
+        className: "Example",
+        methodName: "example",
+        args: object
+      });
+
+      expect(spy).toBeCalled();
+    });
   });
 });

--- a/src/__tests__/PrintLogger.spec.ts
+++ b/src/__tests__/PrintLogger.spec.ts
@@ -1,11 +1,7 @@
 import * as fs from "fs";
 import { PrintLog, PrintLogProxy } from "..";
 import { Logger } from "@nestjs/common";
-import {
-  handlerBeforeCall,
-  handlerAfterCall,
-  printMessage
-} from "../PrintLogger";
+import { printMessage } from "../PrintLogger";
 
 class Dummy {
   @PrintLog()

--- a/src/__tests__/PrintLogger.spec.ts
+++ b/src/__tests__/PrintLogger.spec.ts
@@ -122,9 +122,9 @@ describe("PrintLog", () => {
   describe("#printMessage", () => {
     it("with simple object", () => {
       const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
-      printMessage(Logger, { foo: "bazz" }, "Example#example", "after");
+      printMessage(Logger, "", { foo: "bazz" }, "Example#example");
 
-      expect(spy).toBeCalledWith('Return: {"foo":"bazz"}', "Example#example");
+      expect(spy).toBeCalledWith(' {"foo":"bazz"}', "Example#example");
     });
 
     it("with circular Object", () => {
@@ -133,11 +133,11 @@ describe("PrintLog", () => {
       const citcularObject = { foo: "bar" };
       citcularObject["self"] = citcularObject;
 
-      printMessage(Logger, citcularObject, "Example#example", "after");
+      printMessage(Logger, "", citcularObject, "Example#example");
 
       expect(spy).toBeCalled();
       expect(spy).toBeCalledWith(
-        'Return: {"foo":"bar","self":"~"}',
+        ' {"foo":"bar","self":"~"}',
         "Example#example"
       );
     });

--- a/src/__tests__/PrintLogger.spec.ts
+++ b/src/__tests__/PrintLogger.spec.ts
@@ -1,7 +1,11 @@
 import * as fs from "fs";
 import { PrintLog, PrintLogProxy } from "..";
 import { Logger } from "@nestjs/common";
-import { handlerBeforeCall, handlerAfterCall } from "../PrintLogger";
+import {
+  handlerBeforeCall,
+  handlerAfterCall,
+  printMessage
+} from "../PrintLogger";
 
 class Dummy {
   @PrintLog()
@@ -119,17 +123,12 @@ describe("PrintLog", () => {
     }
   });
 
-  describe("#handlerAfterCall", () => {
-    it("call", () => {
+  describe("#printMessage", () => {
+    it("with simple object", () => {
       const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
-      handlerAfterCall({
-        Logger,
-        className: "Example",
-        methodName: "example",
-        result: [1, 2]
-      });
+      printMessage(Logger, { foo: "bazz" }, "Example#example", "after");
 
-      expect(spy).toBeCalledWith("Return: [1,2]", "Example#example");
+      expect(spy).toBeCalledWith('Return: {"foo":"bazz"}', "Example#example");
     });
 
     it("with circular Object", () => {
@@ -138,12 +137,7 @@ describe("PrintLog", () => {
       const citcularObject = { foo: "bar" };
       citcularObject["self"] = citcularObject;
 
-      handlerAfterCall({
-        Logger,
-        className: "Example",
-        methodName: "example",
-        result: citcularObject
-      });
+      printMessage(Logger, citcularObject, "Example#example", "after");
 
       expect(spy).toBeCalled();
       expect(spy).toBeCalledWith(

--- a/src/__tests__/PrintLogger.spec.ts
+++ b/src/__tests__/PrintLogger.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import { PrintLog, PrintLogProxy } from "..";
 import { Logger } from "@nestjs/common";
-import { handlerBeforeCall } from "../PrintLogger";
+import { handlerBeforeCall, handlerAfterCall } from "../PrintLogger";
 
 class Dummy {
   @PrintLog()
@@ -119,35 +119,37 @@ describe("PrintLog", () => {
     }
   });
 
-  describe("#handlerBeforeCall", () => {
+  describe("#handlerAfterCall", () => {
     it("call", () => {
       const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
-      handlerBeforeCall({
+      handlerAfterCall({
         Logger,
         className: "Example",
         methodName: "example",
-        args: [1, 2]
+        result: [1, 2]
       });
 
-      expect(spy).toBeCalledWith("Call with args: [1,2]", "Example#example");
+      expect(spy).toBeCalledWith("Return: [1,2]", "Example#example");
     });
 
-    it("circular Object", () => {
+    it("with circular Object", () => {
       const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
 
-      const object = { arr: undefined, obj: undefined };
-      object.arr = [object, object];
-      object.arr.push(object.arr);
-      object.obj = object;
+      const citcularObject = { foo: "bar" };
+      citcularObject["self"] = citcularObject;
 
-      handlerBeforeCall({
+      handlerAfterCall({
         Logger,
         className: "Example",
         methodName: "example",
-        args: object
+        result: citcularObject
       });
 
       expect(spy).toBeCalled();
+      expect(spy).toBeCalledWith(
+        'Return: {"foo":"bar","self":"~"}',
+        "Example#example"
+      );
     });
   });
 });

--- a/src/__tests__/PrintLogger.spec.ts
+++ b/src/__tests__/PrintLogger.spec.ts
@@ -91,13 +91,13 @@ describe("PrintLog", () => {
     expect(spy).toBeCalled();
   });
 
-  it("#PrintLogAsync", async () => {
+  it("#PrintLog", async () => {
     const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
     expect(await new Dummy().helloAsync("Bazz")).toEqual(`Hi Bazz`);
     expect(spy).toBeCalled();
   });
 
-  it("#PrintLogAsync handler promise rejects catch", async () => {
+  it("#PrintLog handler promise rejects catch", async () => {
     const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
     try {
       await new Dummy().helloAsyncErrorPromise("Bazz");
@@ -107,7 +107,7 @@ describe("PrintLog", () => {
     }
   });
 
-  it("#PrintLogAsync handler async rejects catch", async () => {
+  it("#PrintLog handler async rejects catch", async () => {
     jest.clearAllMocks();
     const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
     try {


### PR DESCRIPTION
If the object it's circular, print log crashed the main process.
Example for circular Object
```
const citcularObject = { foo: "bar" };
citcularObject["self"] = citcularObject;
```

Use CircularJSON.stringify for fix it