### PR TITLE
Print message callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ new Dummy().hello("Foo");
 
 ```typescript
 class Dummy {
-  @PrintLog({ parseResult: (value) => {...value, token: "*********"}  })
+  @PrintLog({ parseResult: value => ({ ...value, token: "*********" }) })
   foo(secret) {
     return { token: "1234", result: { foo: "bar" } };
   }

--- a/README.md
+++ b/README.md
@@ -100,3 +100,29 @@ class Dummy {
 new Dummy().hello("Foo");
 // f45bg6-56bh-hfc3n-jhu76j [Dummy#hello] Return: Hi Foo
 ```
+
+## PrintLog Options
+
+- Hidden secret information in logs
+
+### parseResult
+
+```typescript
+class Dummy {
+  @PrintLog({ parseResult: (value) => {...value, token: "*********"}  })
+  foo(secret) {
+    return { token: "1234", result: { foo: "bar" } };
+  }
+}
+```
+
+### parseArguments
+
+```typescript
+class Dummy {
+  @PrintLog({ parseArguments: (value: any[]) => ["secret*****"] })
+  foo(secret) {
+    return { token: "1234", result: { foo: "bar" } };
+  }
+}
+```

--- a/src/PrintLogger.ts
+++ b/src/PrintLogger.ts
@@ -24,8 +24,6 @@ export const PrintLogProxy = ({ Logger }) => (
   options: IPrintLogProxyOptions = {}
 ) => {
   const className = options.className || instance.constructor.name;
-  const parseResult = options.parseResult || returnSameValue;
-  const parseArguments = options.parseArguments || returnSameValue;
   const original = instance[methodName];
 
   const proxy = new Proxy(
@@ -34,8 +32,7 @@ export const PrintLogProxy = ({ Logger }) => (
       Logger,
       className,
       methodName,
-      parseArguments,
-      parseResult
+      ...options
     })
   );
   instance[methodName] = proxy;

--- a/src/__tests__/PrintLogger.spec.ts
+++ b/src/__tests__/PrintLogger.spec.ts
@@ -143,3 +143,41 @@ describe("PrintLog", () => {
     });
   });
 });
+
+const parseResult = (value: any) => {
+  delete value.token;
+  return value;
+};
+
+const parseArguments = value => {
+  return [];
+};
+
+class DummyOptions {
+  @PrintLog({ parseResult, parseArguments })
+  foo(secret) {
+    return { token: "1234", result: { foo: "bar" } };
+  }
+}
+
+describe("PrintLog options", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("parseArguments and parseResult", () => {
+    const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
+    new DummyOptions().foo("secret");
+    expect(spy).toHaveBeenNthCalledWith(
+      1,
+      "Call with args: []",
+      "DummyOptions#foo"
+    );
+
+    expect(spy).toHaveBeenNthCalledWith(
+      2,
+      'Return: {"result":{"foo":"bar"}}',
+      "DummyOptions#foo"
+    );
+  });
+});

--- a/src/__tests__/PrintLogger.spec.ts
+++ b/src/__tests__/PrintLogger.spec.ts
@@ -181,3 +181,21 @@ describe("PrintLog options", () => {
     );
   });
 });
+
+describe("PrintLogProxy", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it("parseArguments and parseResult", () => {
+    const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
+    const instance = {
+      foo: secret => ({ token: "1234", result: { foo: "bar" } })
+    };
+
+    PrintLogProxy(instance, "foo", { parseArguments, parseResult });
+
+    instance.foo("Secret");
+    expect(spy.mock.calls[0][0]).toEqual("Call with args: []");
+    expect(spy.mock.calls[1][0]).toEqual('Return: {"result":{"foo":"bar"}}');
+  });
+});

--- a/src/__tests__/PrintLogger.spec.ts
+++ b/src/__tests__/PrintLogger.spec.ts
@@ -168,6 +168,7 @@ describe("PrintLog options", () => {
   it("parseArguments and parseResult", () => {
     const spy = jest.spyOn(Logger, "log").mockImplementation(jest.fn());
     new DummyOptions().foo("secret");
+
     expect(spy).toHaveBeenNthCalledWith(
       1,
       "Call with args: []",
@@ -182,7 +183,7 @@ describe("PrintLog options", () => {
   });
 });
 
-describe("PrintLogProxy", () => {
+describe("PrintLogProxy options", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -191,10 +192,9 @@ describe("PrintLogProxy", () => {
     const instance = {
       foo: secret => ({ token: "1234", result: { foo: "bar" } })
     };
-
     PrintLogProxy(instance, "foo", { parseArguments, parseResult });
-
     instance.foo("Secret");
+
     expect(spy.mock.calls[0][0]).toEqual("Call with args: []");
     expect(spy.mock.calls[1][0]).toEqual('Return: {"result":{"foo":"bar"}}');
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,15 @@ import { Logger as NestLogger } from "@nestjs/common";
 
 import {
   PrintLog as PrintLogCore,
-  PrintLogProxy as PrintLogProxyCore
+  PrintLogProxy as PrintLogProxyCore,
+  IPrintLogOptions
 } from "./PrintLogger";
 
-export const PrintLog = ({ Logger = NestLogger, ...options } = {}) =>
-  PrintLogCore({ Logger, ...options });
+export const PrintLog = ({
+  Logger = NestLogger,
+  ...options
+}: IPrintLogOptions = {}) => PrintLogCore({ Logger, ...options });
 
-export const PrintLogProxy = PrintLogProxyCore({ Logger: NestLogger });
+export const PrintLogProxy = PrintLogProxyCore({
+  Logger: NestLogger
+});


### PR DESCRIPTION
Parse result or arguments

Some times we need to hidde some argument or response, tokens secrets, etc..

Example use:
```typescript
class Dummy {
  @PrintLog({ parseResult: (value) => ({...value, token: "*********"})  })
  foo(secret) {
    return { token: "1234", result: { foo: "bar" } };
  }
}
```